### PR TITLE
fr8x-editor: some cleanup.

### DIFF
--- a/fr8x-data-format-syntax/fr8x-data-format-syntax.factor
+++ b/fr8x-data-format-syntax/fr8x-data-format-syntax.factor
@@ -17,22 +17,25 @@ RENAME: read bitstreams => bsread
     [ ascii encode ] dip packlist ;
 
 : padbitseq ( bitseq -- bitseq )
-    dup length 8 mod dup 0 =
-    [ drop ] [ 8 swap - f <repetition> append ] if ;
+    dup length 8 mod
+    [ 8 swap - f <repetition> append ] unless-zero ;
 
 : dumpbitseq ( bitseq -- ints )
     padbitseq 8 group [ reverse bits>number ] map >byte-array ;
 
 ! Huge thanks to John Benediktsson for the metaprogramming code below
 
-:: bsread-list ( bitreader count width -- list )
-    count [ width bitreader bsread ] replicate ;
+: bsread-list ( bitreader count width -- list )
+    rot '[ _ _ bsread ] replicate ;
 
 : bsread-string ( bitreader count width -- string )
     bsread-list ascii decode ;
 
 SYNTAX: ROLAND-CHUNK-FORMAT:
-      scan-token [ "unpack-" prepend create-in ] [ "pack-" prepend create-in ] [ create-class-in ] tri
+      scan-token
+      [ "unpack-" prepend create-in ]
+      [ "pack-" prepend create-in ]
+      [ create-class-in ] tri
       [
           [ scan-token dup ";" = ] [
               scan-token {

--- a/fr8x-data/fr8x-data.factor
+++ b/fr8x-data/fr8x-data.factor
@@ -8,7 +8,7 @@ FROM: io => read ;
 FROM: assocs => change-at ;
 RENAME: read bitstreams => bsread
 
-IN: fr8x-data 
+IN: fr8x-data
 
 TUPLE: chunkinfo
 { name string }
@@ -18,7 +18,7 @@ TUPLE: chunkinfo
 
 ERROR: loading-error desc ;
 
-: get-header ( -- bin )
+: read-header ( -- bin )
     "\x8d" read-until
     [ "Missing end of preamble marker" loading-error ] unless ;
 
@@ -32,7 +32,7 @@ ERROR: loading-error desc ;
 : get-chunk-tags ( head -- vector )
     children>> second children-tags ;
 
-: get-int-attr ( attrs name -- int ) 
+: get-int-attr ( attrs name -- int )
     swap at*
     [ "Missing expected attribute in XML preamble" loading-error ] unless
     string>number ;
@@ -42,15 +42,16 @@ ERROR: loading-error desc ;
     "size" "number" "offset" [ get-int-attr ] tri-curry@ tri
     chunkinfo boa ;
 
-: parse-chunk-tags ( vector -- chunks ) [ parse-chunk-tag ] map ;
+: parse-chunk-tags ( vector -- chunks )
+    [ parse-chunk-tag ] map ;
 
 : parse-header ( -- chunks )
-    get-header chop-junk bytes>xml get-chunk-tags parse-chunk-tags ;
+    read-header chop-junk bytes>xml get-chunk-tags parse-chunk-tags ;
 
-: load-chunk ( chunkinfo offset -- chunkdata ) 
+: load-chunk ( chunkinfo offset -- chunkdata )
     swap
     [ offset>> + seek-absolute seek-input ] keep
-    [ name>> ] [ count>> ] [ size>> ] tri '[ _ read ] replicate 
+    [ name>> ] [ count>> ] [ size>> ] tri '[ _ read ] replicate
     2array ;
 
 : load-chunks ( chunkinfos -- chunkdatas )
@@ -179,10 +180,10 @@ ROLAND-CHUNK-FORMAT: orchBassData
 : parse-set-file ( -- data )
     parse-header load-chunks decode-known-chunks ;
 
-: load-set-file ( fn --  data )
+: load-set-file ( fn -- data )
     binary [ parse-set-file ] with-file-reader ;
 
-: test ( -- head ) "FR-8X_SET_001.ST8" load-set-file ;
+: load-test-file ( -- head ) "FR-8X_SET_001.ST8" load-set-file ;
 
 : get-chunk ( alist id -- chunk )
     swap at* [ "Missing chunk type" loading-error ] unless ;

--- a/fr8x-ui/fr8x-ui.factor
+++ b/fr8x-ui/fr8x-ui.factor
@@ -1,7 +1,7 @@
 ! Copyright (C) 2014 Mark Green.
 ! See http://factorcode.org/license.txt for BSD license.
 USING: accessors assocs fry kernel locals make math math.parser
-models prettyprint sequences system ui ui.gadgets
+models multiline prettyprint sequences system ui ui.gadgets
 ui.gadgets.book-extras ui.gadgets.borders ui.gadgets.buttons
 ui.gadgets.editors ui.gadgets.grids ui.gadgets.labels
 ui.gadgets.menus ui.gadgets.tracks ;
@@ -69,15 +69,18 @@ IN: fr8x-ui
 : disc-disagree ( button -- )
     close-window 1 exit ;
 
+STRING: warning-text
+Warning: This open source software is provided 'as-is' without
+guarantee of any kind. This editor is not endorsed or authorised
+by Roland or any associated company. Offline editing of set
+files is not supported by Roland. This software and generated
+sets may damage your computer and/or your V-Accordion. You use
+this software and generated sets entirely at your own risk.
+;
+
 : warning-window ( -- gadget )
     vertical <track>
-    "Warning: This open source software is provided 'as-is' without guarantee
-of any kind. This editor is not endorsed or authorised by Roland
-or any associated company. Offline editing of set files is not
-supported by Roland. This software and generated sets may damage
-your computer and/or your V-Accordion. You use this software and 
-generated sets entirely at your own risk." <label>
-    f track-add 
+    warning-text <label> f track-add
     "I agree. Let's do this." [ disc-agree ] <border-button> { 0 10 } <border> f track-add
     "Scary. Get me out of here." [ disc-disagree ] <border-button> { 0 10 } <border> f track-add 
     { 5 5 } <border> ;


### PR DESCRIPTION
Hi Mark,

I cleaned some things up:
- Replace `Your name.` with "your name". :-)
- `ERROR: foo desc` automatically make a `foo` throwing constructor.
- Replace `1 swap nth` with `second`.
- Fixed error in the `register-select` button where the stack effect is wrong because you weren't dropping the button gadget.
- Fixed `show-drop-menu`, not really sure what it is supposed to do, but it "works" now.
