### PR TITLE
cleanups

### DIFF
--- a/fr8x-data/fr8x-data.factor
+++ b/fr8x-data/fr8x-data.factor
@@ -307,7 +307,7 @@ ROLAND-CHUNK-FORMAT: bcrData
     encode-known-chunks values flatten >byte-array write flush ;
 
 : save-set-file ( data fn -- )
-    "resource:work/fr8x-data/standard.preamble" over copy-file
+    "vocab:fr8x-data/standard.preamble" over copy-file
     binary [ write-chunks ] with-file-appender ;
 
 

--- a/fr8x-data/resources.txt
+++ b/fr8x-data/resources.txt
@@ -1,0 +1,3 @@
+midireeds.txt
+midivoices.txt
+standard.preamble

--- a/fr8x-ui/fr8x-ui.factor
+++ b/fr8x-ui/fr8x-ui.factor
@@ -138,7 +138,7 @@ SYMBOL: risky
     [ readln-skipcomments dup ] [ parse-midireed ] produce nip ;
 
 : load-midi-reed-data ( -- reeddata ) 
-    "resource:work/fr8x-data/midireeds.txt" utf8 [ parse-midi-reed-data ] with-file-reader ;
+    "vocab:fr8x-data/midireeds.txt" utf8 [ parse-midi-reed-data ] with-file-reader ;
 
 : disc-agree ( button -- )
     close-window 


### PR DESCRIPTION
Hi,
just a few cleanups to allow the deployed application to work when the code in not under the work directory (ie a separate vocab root). I couldn't go past the missing "FR-8X_SET_012.ST8" file though, even when searching to download a file from the yahoo group you mention in the source
